### PR TITLE
Ensure the bat file will work on Windows

### DIFF
--- a/CCDD.bat
+++ b/CCDD.bat
@@ -1,1 +1,1 @@
-java -cp CCDD.jar:/opt/JDBC/postgresql-9.3-1102.jdbc4.jar:/opt/jruby-9.0.1.0/lib/jruby.jar:/opt/jython2.7.0/jython.jar:/opt/PyDev/plugins/org.python.pydev.jython_4.3.0.201508182223/jython.jar:/opt/groovy-2.4.4/lib/groovy-2.4.4.jar:/opt/groovy-2.4.4/lib/groovy-jsr223-2.4.4.jar CCDD.CcddMain
+java -cp CCDD.jar;.\postgresql-42.2.14.jar CCDD.CcddMain

--- a/CCDD.sh
+++ b/CCDD.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+java -cp CCDD.jar:/opt/JDBC/postgresql-9.3-1102.jdbc4.jar:/opt/jruby-9.0.1.0/lib/jruby.jar:/opt/jython2.7.0/jython.jar:/opt/PyDev/plugins/org.python.pydev.jython_4.3.0.201508182223/jython.jar:/opt/groovy-2.4.4/lib/groovy-2.4.4.jar:/opt/groovy-2.4.4/lib/groovy-jsr223-2.4.4.jar CCDD.CcddMain


### PR DESCRIPTION
The bat file previously used colons to separate class path arguments,
however Windows uses semi-colons to separate class path arguments.
Change the colons to semi-colons to address this issue since bat files
were meant to run on Windows. Also remove some of the arguments since
the paths probably don't make sense for a Windows machine.

Additionally, add a sh file to be used to run CCDD on non-Windows
machines.

This commit addresses issue #79