### PR TITLE
Ensure a Command Argument can be added to a Command

### DIFF
--- a/src/CCDD/CcddDbTableCommandHandler.java
+++ b/src/CCDD/CcddDbTableCommandHandler.java
@@ -5132,19 +5132,23 @@ public class CcddDbTableCommandHandler {
         
         for (TableModification add : additions) {
             // get the data type for this addition
-            String dataType = (String) add.getRowData()[add.getDataTypeColumn()];
-            
-            // Check if this addition represents a root table
-            if (rootStructures.contains(dataType)) {
-                // Ensure that this root table has not already been processed
-                if (!processedDataTypes.contains(dataType)) {
-                    command.append("DELETE from ").append(InternalTable.FIELDS.getTableName())
-                    .append(" WHERE owner_name LIKE '").append(dataType).append(",%'; ");
-                    
-                    // add this data type to the list of processed data types
-                    processedDataTypes.add(dataType);
-                }
-            }
+        	int dataTypeColumn = add.getDataTypeColumn();
+        	if (dataTypeColumn != -1)
+        	{
+	            String dataType = (String) add.getRowData()[dataTypeColumn];
+	            
+	            // Check if this addition represents a root table
+	            if (rootStructures.contains(dataType)) {
+	                // Ensure that this root table has not already been processed
+	                if (!processedDataTypes.contains(dataType)) {
+	                    command.append("DELETE from ").append(InternalTable.FIELDS.getTableName())
+	                    .append(" WHERE owner_name LIKE '").append(dataType).append(",%'; ");
+	                    
+	                    // add this data type to the list of processed data types
+	                    processedDataTypes.add(dataType);
+	                }
+	            }
+        	}
         }
         
         return command.toString();


### PR DESCRIPTION
Inserting a new row in a command and selecting a command argument will
cause an error when storing the changes. This occurs in the function
modifyInternalFieldsTable when checking the data type column of the
table. However, the Command table does not have a data type column, and
an exception gets thrown.

Address this specific issue by checking if the data type column exists
before trying get the row data.

Fixes #83